### PR TITLE
Fix not to override name with localname before downloading annotations.

### DIFF
--- a/genomepy/functions.py
+++ b/genomepy/functions.py
@@ -182,25 +182,27 @@ def install_genome(name, provider, version=None, genome_dir=None, localname=None
         genome_dir = config.get("genome_dir", None)
     if not genome_dir:
         raise norns.exceptions.ConfigError("Please provide or configure a genome_dir")
+    if not localname:
+        localname = name
    
     genome_dir = os.path.expanduser(genome_dir)
     
     # Download genome from provider
     p = ProviderBase.create(provider)
-    name = p.download_genome(
-            name, 
-            genome_dir, 
-            version=version,
-            mask=mask, 
-            localname=localname, 
-            regex=regex, 
-            invert_match=invert_match)
+    p.download_genome(
+        name, 
+        genome_dir, 
+        version=version,
+        mask=mask, 
+        localname=localname, 
+        regex=regex, 
+        invert_match=invert_match)
 
     if annotation:
         # Download annotation from provider
-        p.download_annotation(name, genome_dir, version=version)
+        p.download_annotation(name, localname, genome_dir, version=version)
 
-    g = Genome(name, genome_dir=genome_dir)
+    g = Genome(localname, genome_dir=genome_dir)
     for plugin in get_active_plugins():
         plugin.after_genome_download(g)
 

--- a/genomepy/functions.py
+++ b/genomepy/functions.py
@@ -183,7 +183,7 @@ def install_genome(name, provider, version=None, genome_dir=None, localname=None
     if not genome_dir:
         raise norns.exceptions.ConfigError("Please provide or configure a genome_dir")
     if not localname:
-        localname = name
+        localname = name.replace(' ', '_')
    
     genome_dir = os.path.expanduser(genome_dir)
     

--- a/genomepy/functions.py
+++ b/genomepy/functions.py
@@ -11,6 +11,7 @@ from appdirs import user_config_dir
 from pyfaidx import Fasta,Sequence
 from genomepy.provider import ProviderBase
 from genomepy.plugin import get_active_plugins, init_plugins, activate
+from genomepy.utils import get_localname
 import norns
 
 config = norns.config("genomepy", default="cfg/default.yaml")
@@ -182,10 +183,9 @@ def install_genome(name, provider, version=None, genome_dir=None, localname=None
         genome_dir = config.get("genome_dir", None)
     if not genome_dir:
         raise norns.exceptions.ConfigError("Please provide or configure a genome_dir")
-    if not localname:
-        localname = name.replace(' ', '_')
    
     genome_dir = os.path.expanduser(genome_dir)
+    localname = get_localname(name, localname)
     
     # Download genome from provider
     p = ProviderBase.create(provider)
@@ -200,7 +200,7 @@ def install_genome(name, provider, version=None, genome_dir=None, localname=None
 
     if annotation:
         # Download annotation from provider
-        p.download_annotation(name, localname, genome_dir, version=version)
+        p.download_annotation(name, genome_dir, localname=localname, version=version)
 
     g = Genome(localname, genome_dir=genome_dir)
     for plugin in get_active_plugins():

--- a/genomepy/provider.py
+++ b/genomepy/provider.py
@@ -22,7 +22,7 @@ from pyfaidx import Fasta
 from appdirs import user_cache_dir
 
 from genomepy import exceptions
-from genomepy.utils import filter_fasta
+from genomepy.utils import filter_fasta, get_localname
 from genomepy.__about__ import __version__
 
 my_cache_dir = os.path.join(user_cache_dir("genomepy"), __version__)
@@ -203,7 +203,7 @@ class ProviderBase(object):
                 for seq in not_included:
                     f.write("\t{}\n".format(seq))
     
-    def download_annotation(self, name, localname, genome_dir, version=None):
+    def download_annotation(self, name, genome_dir, localname=None, version=None):
         """
         Download annotation file to to a specific directory
 
@@ -370,7 +370,7 @@ class EnsemblProvider(ProviderBase):
         
         return genome_info["assembly_name"], asm_url
 
-    def download_annotation(self, name, localname, genome_dir, version=None):
+    def download_annotation(self, name, genome_dir, localname=None, version=None):
         """
         Download gene annotation from Ensembl based on genome name.
     
@@ -383,7 +383,7 @@ class EnsemblProvider(ProviderBase):
         version : str , optional
             Ensembl version. By default the latest version is used.
         """
-        localname = localname.replace(" ", "_")
+        localname = get_localname(name, localname)
         genome_info = self._get_genome_info(name)
 
         # parse the division
@@ -526,7 +526,7 @@ class UcscProvider(ProviderBase):
                 "Could not download genome {} from UCSC".format(name))
 
 
-    def download_annotation(self, name, localname, genome_dir, version=None):
+    def download_annotation(self, name, genome_dir, localname=None, version=None):
         """
         Download gene annotation from UCSC based on genomebuild.
     
@@ -539,6 +539,8 @@ class UcscProvider(ProviderBase):
         genome_dir : str
             Genome directory.
         """
+        localname = get_localname(name, localname)
+
         UCSC_GENE_URL = "http://hgdownload.cse.ucsc.edu/goldenPath/{}/database/"
         ANNOS = ["knownGene.txt.gz", "ensGene.txt.gz", "refGene.txt.gz"]
         pred = "genePredToBed"
@@ -786,7 +788,7 @@ class NCBIProvider(ProviderBase):
         # Rename tmp file to real genome file
         shutil.move(new_fa, fa)
 
-    def download_annotation(self, name, localname, genome_dir, version=None):
+    def download_annotation(self, name, genome_dir, localname=None, version=None):
         """
         Download annotation file to to a specific directory
 
@@ -808,7 +810,7 @@ class NCBIProvider(ProviderBase):
                 url = genome["ftp_path"]
                 url += "/" + url.split("/")[-1] + "_genomic.gff.gz"
   
-        localname = localname.replace(" ", "_")
+        localname = get_localname(name, localname)
         out_dir = os.path.join(genome_dir, localname)
         if not os.path.exists(out_dir):
             os.mkdir(out_dir)

--- a/genomepy/provider.py
+++ b/genomepy/provider.py
@@ -202,11 +202,8 @@ class ProviderBase(object):
                 f.write("sequences that were excluded:\n")
                 for seq in not_included:
                     f.write("\t{}\n".format(seq))
-#
-       
-        return myname
     
-    def download_annotation(self, name, genome_dir, version=None):
+    def download_annotation(self, name, localname, genome_dir, version=None):
         """
         Download annotation file to to a specific directory
 
@@ -373,7 +370,7 @@ class EnsemblProvider(ProviderBase):
         
         return genome_info["assembly_name"], asm_url
 
-    def download_annotation(self, name, genome_dir, version=None):
+    def download_annotation(self, name, localname, genome_dir, version=None):
         """
         Download gene annotation from Ensembl based on genome name.
     
@@ -386,6 +383,7 @@ class EnsemblProvider(ProviderBase):
         version : str , optional
             Ensembl version. By default the latest version is used.
         """
+        localname = localname.replace(" ", "_")
         genome_info = self._get_genome_info(name)
 
         # parse the division
@@ -412,20 +410,20 @@ class EnsemblProvider(ProviderBase):
 
         ftp_link = base_url.format(version, genome_info["species"], genome_info["species"].capitalize(), safe_name, version)
 
-        out_dir = os.path.join(genome_dir, name)
+        out_dir = os.path.join(genome_dir, localname)
         if not os.path.exists(out_dir):
             os.mkdir(out_dir)
         # Download the file
         try:
             response = urlopen(ftp_link)
-            gtf_file = out_dir + "/"+ name + ".annotation.gtf.gz"
+            gtf_file = out_dir + "/"+ localname + ".annotation.gtf.gz"
             with open(gtf_file, "wb") as f:
                 f.write(response.read())
         
             bed_file = gtf_file.replace("gtf.gz", "bed")
             cmd = "gtfToGenePred {0} /dev/stdout | genePredToBed /dev/stdin {1} && gzip {1}"
             ret = sp.check_call(cmd.format(gtf_file, bed_file), shell=True)
-            readme = os.path.join(genome_dir, name, "README.txt")
+            readme = os.path.join(genome_dir, localname, "README.txt")
             with open(readme, "a") as f:
                 f.write("annotation url: {}\n".format(ftp_link))
         except Exception:
@@ -528,7 +526,7 @@ class UcscProvider(ProviderBase):
                 "Could not download genome {} from UCSC".format(name))
 
 
-    def download_annotation(self, name, genome_dir, version=None):
+    def download_annotation(self, name, localname, genome_dir, version=None):
         """
         Download gene annotation from UCSC based on genomebuild.
     
@@ -577,10 +575,11 @@ class UcscProvider(ProviderBase):
                     break
             end_col = start_col + 10
            
-            path = os.path.join(genome_dir, name)
+            localname = localname.replace(" ", "_")
+            path = os.path.join(genome_dir, localname)
             if not os.path.exists(path):
                 os.mkdir(path)
-            bed_file = os.path.join(genome_dir, name, name + ".annotation.bed")
+            bed_file = os.path.join(genome_dir, localname, localname + ".annotation.bed")
             cmd = "zcat {} | cut -f{}-{} | {} /dev/stdin {} && gzip {}"
             sp.call(cmd.format(
                 tmp.name, start_col, end_col, pred, bed_file, bed_file), 
@@ -590,7 +589,7 @@ class UcscProvider(ProviderBase):
             cmd = "bedToGenePred {0}.gz /dev/stdout | genePredToGtf file /dev/stdin /dev/stdout -utr -honorCdsStat | sed 's/.dev.stdin/UCSC/' > {1} && gzip {1}"
             ret = sp.check_call(cmd.format(bed_file, gtf_file), shell=True)
         
-            readme = os.path.join(genome_dir, name, "README.txt")
+            readme = os.path.join(genome_dir, localname, "README.txt")
             with open(readme, "a") as f:
                 f.write("annotation url: {}\n".format(url))
         else:
@@ -787,7 +786,7 @@ class NCBIProvider(ProviderBase):
         # Rename tmp file to real genome file
         shutil.move(new_fa, fa)
 
-    def download_annotation(self, name, genome_dir, version=None):
+    def download_annotation(self, name, localname, genome_dir, version=None):
         """
         Download annotation file to to a specific directory
 
@@ -809,14 +808,15 @@ class NCBIProvider(ProviderBase):
                 url = genome["ftp_path"]
                 url += "/" + url.split("/")[-1] + "_genomic.gff.gz"
   
-        out_dir = os.path.join(genome_dir, name)
+        localname = localname.replace(" ", "_")
+        out_dir = os.path.join(genome_dir, localname)
         if not os.path.exists(out_dir):
             os.mkdir(out_dir)
         
         # Download the file
         try:
             response = urlopen(url)
-            gff_file = out_dir + "/"+ name + ".annotation.gff.gz"
+            gff_file = out_dir + "/"+ localname + ".annotation.gff.gz"
             with open(gff_file, "wb") as f:
                 f.write(response.read())
         except Exception:

--- a/genomepy/utils.py
+++ b/genomepy/utils.py
@@ -121,3 +121,10 @@ def run_index_cmd(name, cmd):
         sys.stderr.write("Index for {} failed\n".format(name))
         sys.stderr.write(stdout)
         sys.stderr.write(stderr)
+
+def get_localname(name, localname):
+    """Returns localname if localname is not None, else returns name."""
+    if localname is None:
+        return name.replace(' ', '_')
+    else:
+        return localname.replace(" ", "_")

--- a/tests/test_annotation.py
+++ b/tests/test_annotation.py
@@ -46,9 +46,9 @@ def validate_gzipped_bed(fname):
 def test_annotation():
     tmp = mkdtemp()
     p = genomepy.provider.ProviderBase.create("UCSC")
-    name = "sacCer3"
+    name = localname = "sacCer3"
     
-    p.download_annotation(name, tmp)
+    p.download_annotation(name, name, tmp)
     
     gtf = os.path.join(tmp, name, name + ".annotation.gtf.gz")
     validate_gzipped_gtf(gtf)
@@ -63,7 +63,7 @@ def test_ensembl_annotation():
     p = genomepy.provider.ProviderBase.create("Ensembl")
     
     for name, version in [("GRCh38.p12", 92)]:
-        p.download_annotation(name, tmp)
+        p.download_annotation(name, name, tmp)
     
         gtf = os.path.join(tmp, name, name + ".annotation.gtf.gz")
         validate_gzipped_gtf(gtf)

--- a/tests/test_annotation.py
+++ b/tests/test_annotation.py
@@ -48,7 +48,7 @@ def test_annotation():
     p = genomepy.provider.ProviderBase.create("UCSC")
     name = localname = "sacCer3"
     
-    p.download_annotation(name, name, tmp)
+    p.download_annotation(name, tmp, localname=name)
     
     gtf = os.path.join(tmp, name, name + ".annotation.gtf.gz")
     validate_gzipped_gtf(gtf)
@@ -63,7 +63,7 @@ def test_ensembl_annotation():
     p = genomepy.provider.ProviderBase.create("Ensembl")
     
     for name, version in [("GRCh38.p12", 92)]:
-        p.download_annotation(name, name, tmp)
+        p.download_annotation(name, tmp, localname=name)
     
         gtf = os.path.join(tmp, name, name + ".annotation.gtf.gz")
         validate_gzipped_gtf(gtf)


### PR DESCRIPTION
Resolves #34. 

Currently tested on WBcel235 (Ensembl) and hg38 (UCSC) and verified that genomes and annotations could be downloaded successfully with my own local names.