### PR TITLE
Added URL provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ## [Unreleased]
 
 ### Added
+- Direct downloading from url through url provider.
 
 ### Changed
+- Providers are now case-insensitive.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -209,6 +209,14 @@ These will be saved in BED and GTF format.
 $ genomepy  install hg38 UCSC --annotation
 ```
 
+To facilitate the downloading of genomes not supported by either NCBI, UCSC, or Ensembl, genomes 
+can also be downloaded directly from an url:
+```
+$ genomepy install https://research.nhgri.nih.gov/hydra/download/assembly/\Hm105_Dovetail_Assembly_1.0.fa.gz url
+```
+This installs the genome under the filename of the link, but can be changed with the `--localname` 
+option
+
 Finally, in the spirit of reproducibility all selected options are stored in a `README.txt`. 
 This includes the original name and download location. 
 

--- a/genomepy/cli.py
+++ b/genomepy/cli.py
@@ -1,8 +1,7 @@
 #!/usr/bin/env python
 import click
-import os
-import sys
 import genomepy
+
 
 CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
 

--- a/genomepy/provider.py
+++ b/genomepy/provider.py
@@ -896,4 +896,20 @@ class NCBIProvider(ProviderBase):
         return out_dir
 
 
+@register_provider('URL')
+class UrlProvider(ProviderBase):
+    """
+    URL genome provider.
 
+    Simply download a genome directly through an url.
+    """
+    def get_genome_download_link(self, url, mask=None, version=None):
+        """
+        url : str
+            url of where to download genome from
+
+        Returns
+        ------
+        tuple (url, url) where name is the filename and url the provided url
+        """
+        return url, url

--- a/genomepy/provider.py
+++ b/genomepy/provider.py
@@ -910,6 +910,6 @@ class UrlProvider(ProviderBase):
 
         Returns
         ------
-        tuple (url, url) where name is the filename and url the provided url
+        tuple (url, url)
         """
         return url, url

--- a/genomepy/provider.py
+++ b/genomepy/provider.py
@@ -67,7 +67,7 @@ class ProviderBase(object):
             Provider instance.
         """
         try:
-            return cls._providers[name]()
+            return cls._providers[name.lower()]()
         except KeyError:
             raise Exception("Unknown provider")
 
@@ -76,8 +76,8 @@ class ProviderBase(object):
         """Register method to keep list of providers."""
         def decorator(subclass):
             """Register as decorator function."""
-            cls._providers[provider] = subclass
-            subclass.name = provider
+            cls._providers[provider.lower()] = subclass
+            subclass.name = provider.lower()
             return subclass
         return decorator
     

--- a/genomepy/provider.py
+++ b/genomepy/provider.py
@@ -82,9 +82,9 @@ class ProviderBase(object):
         return decorator
     
     @classmethod
-    def list_providers(self):
+    def list_providers(cls):
         """List available providers.""" 
-        return self._providers.keys()
+        return cls._providers.keys()
 
     def __hash__(self):
         return hash(str(self.__class__))

--- a/genomepy/utils.py
+++ b/genomepy/utils.py
@@ -138,7 +138,7 @@ def get_localname(name, localname):
     if localname is None:
         try:
             urllib.request.urlopen(name)
-        except IOError:
+        except (IOError, ValueError):
             return name.replace(' ', '_')
         else:
             # try to get the name from the url

--- a/genomepy/utils.py
+++ b/genomepy/utils.py
@@ -104,8 +104,7 @@ def mkdir_p(path):
 
 
 def cmd_ok(cmd):
-    """Returns True if cmd can be run.
-    """
+    """Returns True if cmd can be run."""
     try:
         sp.check_call(cmd, stderr=sp.PIPE, stdout=sp.PIPE)
     except sp.CalledProcessError:

--- a/genomepy/utils.py
+++ b/genomepy/utils.py
@@ -4,6 +4,7 @@ import os
 import re
 import sys
 import subprocess as sp
+import urllib.request
 
 from pyfaidx import Fasta
 
@@ -135,12 +136,13 @@ def get_localname(name, localname):
       else: returns name
     """
     if localname is None:
-        # name is an url if it contains . / and :
-        if all(char in name for char in ['.', '/', ':']):
-            # then parse url to filename: http://path/to/file.fa.gz -> file
+        try:
+            urllib.request.urlopen(name)
+        except IOError:
+            return name.replace(' ', '_')
+        else:
+            # try to get the name from the url
             name = name[name.rfind("/") + 1:]
             return name[:name.find(".")]
-        else:
-            return name.replace(' ', '_')
     else:
         return localname.replace(" ", "_")

--- a/genomepy/utils.py
+++ b/genomepy/utils.py
@@ -130,8 +130,18 @@ def run_index_cmd(name, cmd):
 
 
 def get_localname(name, localname):
-    """Returns localname if localname is not None, else returns name."""
+    """
+    Returns localname if localname is not None, else;
+      if name is an url (URL provider): Returns parsed filename from name
+      else: returns name
+    """
     if localname is None:
-        return name.replace(' ', '_')
+        # name is an url if it contains . / and :
+        if all(char in name for char in ['.', '/', ':']):
+            # then parse url to filename: http://path/to/file.fa.gz -> file
+            name = name[name.rfind("/") + 1:]
+            return name[:name.find(".")]
+        else:
+            return name.replace(' ', '_')
     else:
         return localname.replace(" ", "_")

--- a/tests/test_genomepy.py
+++ b/tests/test_genomepy.py
@@ -137,12 +137,11 @@ def test_url_genome():
     """
     tmp = mkdtemp()
     genomepy.install_genome(
-        "http://hgdownload.soe.ucsc.edu/goldenPath/sacCer3/bigZips/chromFa.tar.gz", "url",
-        genome_dir=tmp, localname='Release_6_plus_ISO1_MT'
+        "http://hgdownload.soe.ucsc.edu/goldenPath/ce11/bigZips/chromFa.tar.gz", "url",
+        genome_dir=tmp, localname='url_test'
     )
-    g = genomepy.Genome("Release_6_plus_ISO1_MT", genome_dir=tmp)
-    seq = g["3L"][10637840:10637875]
-    assert str(seq).upper() == "TTTGCAACAGCTGCCGCAGTGTGACCGTTGTACTG"
+    g = genomepy.Genome("url_test", genome_dir=tmp)
+    assert str(g['chrI'][:12]).lower() == "gcctaagcctaa"
     shutil.rmtree(tmp)
 
 

--- a/tests/test_genomepy.py
+++ b/tests/test_genomepy.py
@@ -127,3 +127,38 @@ def test_regexp_filter():
         assert len(fa.keys()) == match
         fa = genomepy.utils.filter_fasta(fname, tmpfa, regex=regex, v=True, force=True)
         assert len(fa.keys()) == no_match
+
+
+def test_url_genome():
+    """Test URL.
+
+    Download S. cerevisiae genome directly from an url from UCSC and retrieve a
+    specific sequence.
+    """
+    tmp = mkdtemp()
+    genomepy.install_genome(
+        "http://hgdownload.soe.ucsc.edu/goldenPath/sacCer3/bigZips/chromFa.tar.gz", "url",
+        genome_dir=tmp, localname='Release_6_plus_ISO1_MT'
+    )
+    g = genomepy.Genome("Release_6_plus_ISO1_MT", genome_dir=tmp)
+    seq = g["3L"][10637840:10637875]
+    assert str(seq).upper() == "TTTGCAACAGCTGCCGCAGTGTGACCGTTGTACTG"
+    shutil.rmtree(tmp)
+
+
+def test_bad_url():
+    """Test URL.
+
+    Try to download a non-genome url link.
+    """
+    with pytest.raises(ValueError):
+        genomepy.install_genome("www.google.com", "url")
+
+
+def test_nonexisting_url():
+    """Test URL.
+
+    Try to download a non-genome url link.
+    """
+    with pytest.raises(ValueError):
+        genomepy.install_genome("this is not an url", "url")


### PR DESCRIPTION
See issue #46 

Two parts:
- some minor cleanups I came across in the code
- I added an URL provider. The URL provider is a barebone Provider class, which just returns the url when `get_genome_download_link` is called. I changed the `get_localname` function to get a localname from an url. I am not sure however if my 'heuristic' approach to spotting an url always works (checking for / . and : ). I could for instance change it so that it checks if `urlopen(name)` works.  

You can now install through:
`genomepy install https://research.nhgri.nih.gov/hydra/download/assembly/Hm105_Dovetail_Assembly_1.0.fa.gz URL`

Is `URL` a good provider name? Capitals or not? Should we be afraid this breaks something somewhere? Should I add tests? The current test already fails at the build stage, does this indicate something is already wrong? Should I update the readme?